### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
 		<commons-dbcp.version>20030825.184428</commons-dbcp.version>
 		<common-pool.version>20030825.183949</common-pool.version>
-		<common-collections.version>3.2.1</common-collections.version>
+		<common-collections.version>3.2.2</common-collections.version>
 		<mail.version>1.4.1</mail.version>
 		<commons-io.version>2.4</commons-io.version>
 		<rome.version>1.0</rome.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
